### PR TITLE
Fixed exception when Common.Logging dependency is missing.

### DIFF
--- a/NHttp/LogManager.cs
+++ b/NHttp/LogManager.cs
@@ -19,7 +19,16 @@ namespace NHttp
 
         static LogManager()
         {
-            var assembly = Assembly.Load("Common.Logging");
+            Assembly assembly = null;
+            try
+            {
+                assembly = Assembly.Load("Common.Logging");
+            }
+            catch (System.IO.FileNotFoundException)
+            {
+                // Ignore missing assembly, logging will not be enabled.
+            }
+
             if (assembly == null)
                 return;
 


### PR DESCRIPTION
I've made a small improvement.

Even though NHttp didn't directly depend on Common.Logging.dll, it still raised an exception when an HttpServer instance was constructed.
