### PR TITLE
Keys with multiple values for QueryString and Forms.

### DIFF
--- a/NHttp.Test/WebRequestFixtures/BasicRequest.cs
+++ b/NHttp.Test/WebRequestFixtures/BasicRequest.cs
@@ -40,6 +40,33 @@ namespace NHttp.Test.WebRequestFixtures
         }
 
         [Test]
+        public void QueryStringKeyWithMultipleValues()
+        {
+            using (var server = new HttpServer())
+            {
+                server.RequestReceived += (s, e) =>
+                {
+                    Assert.That(e.Request.QueryString.AllKeys, Is.EquivalentTo(new[] { "key" }));
+                    Assert.That(e.Request.QueryString.GetValues("key"), Is.EquivalentTo(new[] { "first", "second", "third" }));
+                    Assert.AreEqual(e.Request.QueryString["key"], "first,second,third");
+
+                    using (var writer = new StreamWriter(e.Response.OutputStream))
+                    {
+                        writer.Write(ResponseText);
+                    }
+                };
+
+                server.Start();
+
+                var request = (HttpWebRequest)WebRequest.Create(
+                    String.Format("http://{0}/?key=first&key=second&key=third", server.EndPoint)
+                );
+
+                Assert.AreEqual(ResponseText, GetResponseFromRequest(request));
+            }
+        }
+
+        [Test]
         public void NoInputStreamWithGet()
         {
             using (var server = new HttpServer())

--- a/NHttp/HttpClient.cs
+++ b/NHttp/HttpClient.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
@@ -36,7 +37,7 @@ namespace NHttp
 
         public Dictionary<string, string> Headers { get; private set; }
 
-        public Dictionary<string, string> PostParameters { get; set; }
+        public NameValueCollection PostParameters { get; set; }
 
         public List<HttpMultiPartItem> MultiPartItems { get; set; }
 
@@ -89,7 +90,7 @@ namespace NHttp
             Protocol = null;
             Request = null;
             Headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-            PostParameters = null;
+            PostParameters = new NameValueCollection();
 
             if (MultiPartItems != null)
             {

--- a/NHttp/HttpRequest.cs
+++ b/NHttp/HttpRequest.cs
@@ -62,7 +62,7 @@ namespace NHttp
         {
             ParseHeaders(client);
 
-            Form = CreateCollection(client.PostParameters);
+            Form = client.PostParameters;
 
             ParseMultiPartItems(client);
 
@@ -246,10 +246,9 @@ namespace NHttp
 
             Path = parts[0];
 
+            QueryString = new NameValueCollection();
             if (parts.Length == 2)
-                QueryString = CreateCollection(HttpUtil.UrlDecode(parts[1]));
-            else
-                QueryString = new NameValueCollection();
+                 HttpUtil.UrlDecodeTo(parts[1], QueryString);
 
             string host;
             string port;

--- a/NHttp/HttpUrlEncodedRequestParser.cs
+++ b/NHttp/HttpUrlEncodedRequestParser.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.IO;
 using System.Text;
 
@@ -38,7 +39,7 @@ namespace NHttp
                 content = reader.ReadToEnd();
             }
 
-            Client.PostParameters = HttpUtil.UrlDecode(content);
+            HttpUtil.UrlDecodeTo(content, Client.PostParameters);
         }
     }
 }

--- a/NHttp/HttpUtil.cs
+++ b/NHttp/HttpUtil.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Globalization;
 using System.Text;
 
@@ -69,17 +70,17 @@ namespace NHttp
             }
         }
 
-        public static Dictionary<string, string> UrlDecode(string content)
+        public static void UrlDecodeTo(string content, NameValueCollection target)
         {
-            return UrlDecode(content, Encoding.UTF8);
+            UrlDecodeTo(content, target, Encoding.UTF8);
         }
 
-        public static Dictionary<string, string> UrlDecode(string content, Encoding encoding)
+        public static void UrlDecodeTo(string content, NameValueCollection target, Encoding encoding)
         {
             if (encoding == null)
                 throw new ArgumentNullException("encoding");
-
-            var result = new Dictionary<string, string>();
+            if (target == null)
+                throw new ArgumentNullException("target");
 
             string[] parts = content.Split('&');
 
@@ -90,10 +91,8 @@ namespace NHttp
                 string key = UriDecode(item[0], encoding);
                 string value = item.Length == 1 ? "" : UriDecode(item[1], encoding);
 
-                result[key] = value;
+                target.Add(key, value);
             }
-
-            return result;
         }
 
         public static string UriDecode(string value)


### PR DESCRIPTION
I've changed few parts of the request parsing code to add support for multivalued keys. This is especially needed for <select multiple> HTML elements. As far I as I know, that is the reason why everything in ASP.NET Request is a NameValueCollection - it supports the correct way to do this (key=first&key=second&key=third should be equivalent to key=first,second,third).

I've added a test for it, the result of the rest of the test suite is unchanged (the file upload test fail for me).

I'm not sure about just assigning HttpClient.PostParameters to HttpRequest.Form (from the architectural point of view), as neither are/were previously immutable, but creating a copy seemed like an unnecessary operation.

According to https://stackoverflow.com/questions/4371328/are-duplicate-http-response-headers-acceptable, the same shoud apply to headers, but that change would be much deeper.
