### PR TITLE
Move BeginAcceptTcpClient() to top of AcceptTcpClientCallback() to prevent exceptions stopping listen loop

### DIFF
--- a/NHttp/HttpServer.cs
+++ b/NHttp/HttpServer.cs
@@ -249,6 +249,8 @@ namespace NHttp
         {
             try
             {
+                BeginAcceptTcpClient(); // Do this first so as exception below doesn't interrupt listening
+
                 var listener = _listener; // Prevent race condition.
 
                 if (listener == null)
@@ -268,9 +270,7 @@ namespace NHttp
 
                 RegisterClient(client);
 
-                client.BeginRequest();
-
-                BeginAcceptTcpClient();
+                client.BeginRequest();                
             }
             catch (ObjectDisposedException)
             {


### PR DESCRIPTION
An exception in the body of AcceptTcpClientCallback() will cause the log message Log.Info("Failed to accept TCP client", ex); to be written, after which no further connections will be accepted as BeginAcceptTcpClient() is never called.